### PR TITLE
Version 1.0.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Fork, then clone the repo:
 ```
-git clone git@github.com:your-username/swiss-village-directory.git
+git clone git@github.com:your-username/swiss_village_directory.git
 ```
 
 Set up your machine:
@@ -28,7 +28,7 @@ Push to your fork and [submit a pull request][pr].
 git push origin your-branch-name
 ```
 
-[pr]: https://github.com/renuo/swiss-village-directory/compare/
+[pr]: https://github.com/renuo/swiss_village_directory/compare/
 
 At this point you're waiting on us. We like to at least comment on pull requests within three business days
 (and, typically, one business day). We may suggest some changes or improvements or alternatives.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-[![Build Status](https://travis-ci.org/renuo/swiss-village-directory.svg?branch=master)](https://travis-ci.org/renuo/swiss-village-directory)
+[![Build Status](https://travis-ci.org/renuo/swiss_village_directory.svg?branch=master)](https://travis-ci.org/renuo/swiss_village_directory)
 
 # Swiss Village Directory
 
 This gem provides a data set of all swiss villages taken out of the
 "Ortschaftenverzeichnis" ([ch.swisstopo-vd.ortschaftenverzeichnis_plz][4])
-The data set made available through a ruby object called `Village` contains
+The data set made available through a ruby object called [`Village`](https://github.com/renuo/swiss-village-directory/blob/master/lib/swiss_village_directory/village.rb) contains
 the following fields.
 
-* Village name
-* Zip code
-* One digit spare
-* Municipal area/Commune
-* Canton
-* Latitude (WGS84)
-* Longitude (WGS84)
+* name
+* zip_code
+* one_digit_spare
+* commune
+* canton
+* latitude (WGS84)
+* longitude (WGS84)
 
 The data source can be downloaded as CSV here: [PLZO_CSV_WGS84.zip][5]
 
@@ -22,7 +22,7 @@ The data source can be downloaded as CSV here: [PLZO_CSV_WGS84.zip][5]
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'swiss-village-directory'
+gem 'swiss_village_directory'
 ```
 
 And then execute:
@@ -31,7 +31,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install swiss-village-directory
+    $ gem install swiss_village_directory
 
 ## Usage
 

--- a/lib/swiss_village_directory/version.rb
+++ b/lib/swiss_village_directory/version.rb
@@ -1,3 +1,3 @@
 module SwissVillageDirectory
-  VERSION = '0.4.0'.freeze
+  VERSION = '1.0.0'.freeze
 end

--- a/lib/swiss_village_directory/village.rb
+++ b/lib/swiss_village_directory/village.rb
@@ -1,15 +1,17 @@
+require 'bigdecimal/util'
+
 module SwissVillageDirectory
   class Village
     attr_reader :name, :zip_code, :one_digit_spare, :commune, :canton, :longitude, :latitude
 
     def initialize(name, zip_code, one_digit_spare, commune, canton, longitude, latitude)
       @name = name
-      @zip_code = zip_code.to_i
+      @zip_code = zip_code.to_s
       @one_digit_spare = one_digit_spare.to_i
       @commune = commune
       @canton = canton
-      @longitude = longitude.to_f
-      @latitude = latitude.to_f
+      @longitude = longitude.to_d
+      @latitude = latitude.to_d
     end
   end
 end

--- a/spec/swiss_village_directory/repository_spec.rb
+++ b/spec/swiss_village_directory/repository_spec.rb
@@ -17,7 +17,7 @@ describe SwissVillageDirectory::Repository do
   it 'reads the values from an exel and shows the right ones' do
     village = repo.villages.find { |v| v.name == 'Aadorf' && v.canton == 'TG' }
     expect(village.name).to eq('Aadorf')
-    expect(village.zip_code).to eq(8355)
+    expect(village.zip_code).to eq('8355')
     expect(village.one_digit_spare).to eq(0)
     expect(village.commune).to eq('Aadorf')
     expect(village.canton).to eq('TG')
@@ -30,7 +30,8 @@ describe SwissVillageDirectory::Repository do
       expect(repo.find_all_by(name: 'Aadorf_wrong').count).to eq(0)
       expect(repo.find_all_by(name: 'Aadorf').count).to eq(2)
       expect(repo.find_all_by(zip_code: 0).count).to eq(0)
-      expect(repo.find_all_by(zip_code: 8355).count).to eq(2)
+      expect(repo.find_all_by(zip_code: 8355).count).to eq(0)
+      expect(repo.find_all_by(zip_code: '8355').count).to eq(2)
       expect(repo.find_all_by(one_digit_spare: 1000).count).to eq(0)
       expect(repo.find_all_by(one_digit_spare: 0).count).to be > 1
       expect(repo.find_all_by(commune: 'nonexistingAadorf').count).to eq(0)

--- a/spec/swiss_village_directory/village_spec.rb
+++ b/spec/swiss_village_directory/village_spec.rb
@@ -11,14 +11,11 @@ describe SwissVillageDirectory::Village do
   it { is_expected.to respond_to(:latitude) }
   it { is_expected.to respond_to(:longitude) }
 
-  it 'has a numeric values' do
-    expect_is_numeric(subject.zip_code)
-    expect_is_numeric(subject.one_digit_spare)
-    expect_is_numeric(subject.latitude)
-    expect_is_numeric(subject.longitude)
-  end
-
-  def expect_is_numeric(value)
-    expect(value).to be_a Numeric
+  it 'has the correct value types' do
+    expect(subject.name).to be_a String
+    expect(subject.zip_code).to be_a String
+    expect(subject.one_digit_spare).to be_a Numeric
+    expect(subject.latitude).to be_a Numeric
+    expect(subject.longitude).to be_a Numeric
   end
 end

--- a/swiss-village-directory.gemspec
+++ b/swiss-village-directory.gemspec
@@ -3,13 +3,13 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'swiss_village_directory/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'swiss-village-directory'
+  spec.name          = 'swiss_village_directory'
   spec.version       = SwissVillageDirectory::VERSION
   spec.authors       = ['Josua Schmid', 'Simon Huber']
   spec.email         = ['josua.schmid@renuo.ch', 'simon.huber@renuo.ch']
 
   spec.summary       = 'This gem provides a data set of all swiss villages taken out of the "Ortschaftenverzeichnis" (https://data.geo.admin.ch/ch.swisstopo-vd.ortschaftenverzeichnis_plz/readme.txt)'
-  spec.homepage      = 'https://github.com/renuo/swiss-village-directory'
+  spec.homepage      = 'https://github.com/renuo/swiss_village_directory'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }


### PR DESCRIPTION
This is a major version because it has breaking changes. In particular it changes the zip_code from being a number to a string. ZipCodes are, in fact, strings, and nothing that needs arythmetical operations.

This PR changes also the gem name from `swiss-village-directory` to `swiss_village_directory` since we have `SwissVillageDirectory` and not `Swiss::Village::Directory`, making it also not necessary anymore to explicitly do the right `require` call.

After this gets merged I'll release the gem under the new name and switch also from master to main.